### PR TITLE
[NEW] Zip64 files and forEach method

### DIFF
--- a/adm-zip.js
+++ b/adm-zip.js
@@ -339,6 +339,14 @@ module.exports = function (/*String*/input) {
 			return getEntry(name);
 		},
 
+		getEntryCount: function() {
+			return _zip.getEntryCount();
+		},
+
+		forEach: function(callback) {
+			return _zip.forEach(callback);
+		},
+
 		/**
 		 * Extracts the given entry to the given targetPath
 		 * If the entry is a directory inside the archive, the entire directory and it's subdirectories will be extracted

--- a/headers/mainHeader.js
+++ b/headers/mainHeader.js
@@ -31,19 +31,37 @@ module.exports = function () {
 
         loadFromBinary : function(/*Buffer*/data) {
             // data should be 22 bytes and start with "PK 05 06"
-            if (data.length !== Constants.ENDHDR || data.readUInt32LE(0) !== Constants.ENDSIG)
-                throw Utils.Errors.INVALID_END;
+            // or be 56+ bytes and start with "PK 06 06" for Zip64
+            if ((data.length !== Constants.ENDHDR || data.readUInt32LE(0) !== Constants.ENDSIG) &&
+                (data.length < Constants.ZIP64HDR || data.readUInt32LE(0) !== Constants.ZIP64SIG)) {
 
-            // number of entries on this volume
-            _volumeEntries = data.readUInt16LE(Constants.ENDSUB);
-            // total number of entries
-            _totalEntries = data.readUInt16LE(Constants.ENDTOT);
-            // central directory size in bytes
-            _size = data.readUInt32LE(Constants.ENDSIZ);
-            // offset of first CEN header
-            _offset = data.readUInt32LE(Constants.ENDOFF);
-            // zip file comment length
-            _commentLength = data.readUInt16LE(Constants.ENDCOM);
+                throw Utils.Errors.INVALID_END;
+            }
+
+            if (data.readUInt32LE(0) === Constants.ENDSIG) {
+                // number of entries on this volume
+                _volumeEntries = data.readUInt16LE(Constants.ENDSUB);
+                // total number of entries
+                _totalEntries = data.readUInt16LE(Constants.ENDTOT);
+                // central directory size in bytes
+                _size = data.readUInt32LE(Constants.ENDSIZ);
+                // offset of first CEN header
+                _offset = data.readUInt32LE(Constants.ENDOFF);
+                // zip file comment length
+                _commentLength = data.readUInt16LE(Constants.ENDCOM);
+            } else {
+                // number of entries on this volume
+                _volumeEntries = Utils.readBigUInt64LE(data, Constants.ZIP64SUB);
+                // total number of entries
+                _totalEntries = Utils.readBigUInt64LE(data, Constants.ZIP64TOT);
+                // central directory size in bytes
+                _size = Utils.readBigUInt64LE(data, Constants.ZIP64SIZ);
+                // offset of first CEN header
+                _offset = Utils.readBigUInt64LE(data, Constants.ZIP64OFF);
+
+                _commentLength = 0;
+            }
+
         },
 
         toBinary : function() {

--- a/util/constants.js
+++ b/util/constants.js
@@ -47,6 +47,26 @@ module.exports = {
     ENDOFF           : 16, // offset of first CEN header
     ENDCOM           : 20, // zip file comment length
 
+    END64HDR         : 20, // zip64 END header size
+    END64SIG         : 0x07064b50, // zip64 Locator signature, "PK\006\007"
+    END64START       : 4, // number of the disk with the start of the zip64
+    END64OFF         : 8, // relative offset of the zip64 end of central directory
+    END64NUMDISKS    : 16, // total number of disks
+
+    ZIP64SIG         : 0x06064b50, // zip64 signature, "PK\006\006"
+    ZIP64HDR         : 56, // zip64 record minimum size
+    ZIP64LEAD        : 12, // leading bytes at the start of the record, not counted by the value stored in ZIP64SIZE
+    ZIP64SIZE        : 4, // zip64 size of the central directory record
+    ZIP64VEM         : 12, // zip64 version made by
+    ZIP64VER         : 14, // zip64 version needed to extract
+    ZIP64DSK         : 16, // zip64 number of this disk
+    ZIP64DSKDIR      : 20, // number of the disk with the start of the record directory
+    ZIP64SUB         : 24, // number of entries on this disk
+    ZIP64TOT         : 32, // total number of entries
+    ZIP64SIZB        : 40, // zip64 central directory size in bytes
+    ZIP64OFF         : 48, // offset of start of central directory with respect to the starting disk number
+    ZIP64EXTRA       : 56, // extensible data sector
+
     /* Compression methods */
     STORED           : 0, // no compression
     SHRUNK           : 1, // shrunk

--- a/util/utils.js
+++ b/util/utils.js
@@ -48,6 +48,13 @@ module.exports = (function() {
         return files;
     }
 
+    function readBigUInt64LE(/*Buffer*/buffer, /*int*/index) {
+        var slice = Buffer.from(buffer.slice(index, index + 8));
+        slice.swap64();
+
+        return parseInt(`0x${ slice.toString('hex') }`);
+    }
+
     return {
         makeDir : function(/*String*/path) {
             mkdirSync(path);
@@ -202,6 +209,8 @@ module.exports = (function() {
                 return Buffer.from(input, 'utf8');
             }
         },
+
+        readBigUInt64LE,
 
         Constants : Constants,
         Errors : Errors


### PR DESCRIPTION
- [X] Adds support to files with more than 65535 entries
- [X] Adds a method to iterate over entries without loading all of them to memory at the same time.